### PR TITLE
add starter queries for SQLcaster users

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,6 +11,13 @@ const CANNED_QUERIES = [
   "select * from casts \n where username = 'whatrocks' and reactions is not null \n order by reactions desc \n limit 3;",
   "SELECT avatar_url, count(*) as deleted_casts from casts \nwhere deleted is not null \n group by 1 \n order by deleted_casts desc \n limit 100;",
   "SELECT \n DATE_TRUNC('month',to_timestamp(published_at*1000000)) AS month, \n COUNT(*) AS count \n FROM casts \n group by DATE_TRUNC('month',to_timestamp(published_at*1000000)) \n ORDER BY 2 DESC",
+  "SELECT avatar_url, display_name, reply_parent_username, published_at FROM casts \n WHERE reply_parent_username = 'a16zcrypto' \n ORDER BY published_at DESC \n LIMIT 10",
+  "SELECT COUNT(display_name), reply_parent_username FROM casts \n WHERE reply_parent_username = 'a16zcrypto' \n GROUP BY reply_parent_username \n LIMIT 10",
+  "SELECT avatar_url, display_name, text, published_at FROM casts \n WHERE display_name = 'Dan Romero' \n ORDER BY published_at DESC \n LIMIT 10",
+  "SELECT COUNT(DISTINCT(ADDRESS)) FROM casts \n LIMIT 10",
+  "SELECT avatar_url, display_name, COUNT(recasters) AS num_recasters FROM casts \n GROUP BY avatar_url, display_name \n ORDER BY num_recasters DESC \n LIMIT 10",
+  "SELECT avatar_url, display_name, COUNT(mentions) AS num_mentions FROM casts \n GROUP BY avatar_url, display_name \n ORDER BY num_mentions DESC \n LIMIT 10",
+  "SELECT avatar_url, display_name, COUNT(DELETED) AS num_deleted FROM casts \n GROUP BY avatar_url, display_name \n ORDER BY num_deleted DESC \n LIMIT 10"
 ];
 
 export default function Home({}) {

--- a/sql_queries/starter_queries.sql
+++ b/sql_queries/starter_queries.sql
@@ -1,0 +1,77 @@
+-- suggested starter queries for users of SQLcaster
+
+
+-- List the top-10 most recent users (avatar_url & display_name) that have replied to a user account
+-- sample account: 'a16zcrypto'
+SELECT 
+   avatar_url
+  , display_name
+  , reply_parent_username
+  , published_at
+FROM casts
+WHERE reply_parent_username = 'a16zcrypto'
+ORDER BY published_at DESC
+LIMIT 10
+
+
+-- Count number of users (display_name) on Farcaster who have replied to an account
+-- sample account: 'a16zcrypto'
+SELECT 
+   COUNT(display_name)
+  , reply_parent_username
+FROM casts
+WHERE reply_parent_username = 'a16zcrypto'
+GROUP BY reply_parent_username
+LIMIT 10
+
+-- Query 10 most recently published casts by a user account
+-- sample account: 'Dan Romero'
+SELECT 
+   avatar_url
+  , display_name
+  , text 
+  , published_at
+FROM casts
+WHERE display_name = 'Dan Romero'
+ORDER BY published_at DESC
+LIMIT 10
+
+-- Count unique addresses on Farcaster
+SELECT 
+   COUNT(DISTINCT(ADDRESS))
+FROM casts
+LIMIT 10
+
+-- List the top-10 user accounts (avatar_url & display_name) by number of recasters, in descending order
+SELECT 
+   avatar_url
+  , display_name
+  , COUNT(recasters) AS num_recasters
+FROM casts
+GROUP BY avatar_url, display_name
+ORDER BY num_recasters DESC
+LIMIT 10
+
+
+-- List the top-10 user accounts (avatar_url & display_name) by number of mentions, in descending order
+SELECT 
+   avatar_url
+  , display_name
+  , COUNT(mentions) AS num_mentions
+FROM casts
+GROUP BY avatar_url, display_name
+ORDER BY num_mentions DESC
+LIMIT 10
+
+-- List the top-10 user accounts (avatar_url & display_name) by nunber of deleted casts, in descending order
+SELECT 
+   avatar_url
+  , display_name
+  , COUNT(DELETED) AS num_deleted
+FROM casts
+GROUP BY avatar_url, display_name
+ORDER BY num_deleted DESC
+LIMIT 10
+
+
+


### PR DESCRIPTION
gm @whatrocks I've added a directory `sql_queries` with a file called `starter_queries.sql` for SQLcaster users.

seven queries with descriptions are contained in the file. 

all queries have been tested and are currently working on [SQLcaster](https://sqlcaster.xyz/).

**note**: an update in data indexing could change results. 